### PR TITLE
Add fuzzing targets for SHA256 & SHA384

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ sodiumoxide = "0.2.5"
 ring = "0.16.9"
 blake2-rfc = "0.2.18"
 chacha = "0.3.0"
-orion = { git = "https://github.com/brycx/orion", branch = "master" }
+orion = { git = "https://github.com/brycx/orion", branch = "sha2-full" }
 rust-argon2 = "0.8.1"
 
 [[bin]]

--- a/src/aead_stream.rs
+++ b/src/aead_stream.rs
@@ -4,16 +4,16 @@ extern crate orion;
 extern crate sodiumoxide;
 pub mod utils;
 
+use core::convert::TryFrom;
 use orion::hazardous::aead::streaming::*;
 use orion::hazardous::stream::chacha20::SecretKey;
 use sodiumoxide::crypto::secretstream::xchacha20poly1305 as sodium_stream;
 use utils::{make_seeded_rng, rand_vec_in_range, ChaChaRng, Rng, RngCore};
-use core::convert::TryFrom;
 
 /// Randomly select which tag should be passed to sealing a chunk.
 fn select_tag(seeded_rng: &mut ChaChaRng) -> (StreamTag, sodium_stream::Tag) {
     let rnd_choice: u8 = seeded_rng.gen_range(0, 4);
-    
+
     let orion_tag = StreamTag::try_from(rnd_choice).expect("UNEXPECTED: RNG range number invalid");
     let other_tag = match rnd_choice {
         0 => sodium_stream::Tag::Message,

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -5,8 +5,9 @@ extern crate orion;
 extern crate ring;
 pub mod utils;
 
-use orion::hazardous::hash::blake2b;
+use orion::hazardous::hash::sha2;
 use orion::hazardous::hash::sha2::sha512::{self, SHA512_BLOCKSIZE};
+use orion::{errors::UnknownCryptoError, hazardous::hash::blake2b};
 use utils::{make_seeded_rng, rand_vec_in_range, ChaChaRng, Rng};
 
 const BLAKE2B_BLOCKSIZE: usize = 128;
@@ -70,30 +71,111 @@ fn fuzz_blake2b(fuzzer_input: &[u8], seeded_rng: &mut ChaChaRng) {
     }
 }
 
-// TODO: Add SHA256/384
+// A wrapper trait to reduce duplicate functional test-code when fuzzing SHA256/384/512.
+trait Sha2FuzzType {
+    fn new() -> Self;
 
-fn fuzz_sha512(fuzzer_input: &[u8]) {
-    let mut orion_ctx = sha512::Sha512::new();
+    fn update(&mut self, data: &[u8]) -> Result<(), UnknownCryptoError>;
+
+    fn finalize(&mut self) -> Result<T: PartialEq, UnknownCryptoError>;
+
+    fn digest(data: &[u8]) -> Result<T: PartialEq, UnknownCryptoError>;
+
+    fn get_blocksize() -> usize;
+}
+
+impl Sha2FuzzType for sha2::sha256::Sha256 {
+    fn new() -> Self {
+        return sha2::sha256::Sha256::new();
+    }
+
+    fn update(&mut self, data: &[u8]) -> Result<(), UnknownCryptoError> {
+        self.update(data)
+    }
+
+    fn finalize(&mut self) -> Result<sha2::sha256::Digest, UnknownCryptoError> {
+        self.finalize()
+    }
+
+    fn digest(data: &[u8]) -> Result<sha2::sha256::Digest, UnknownCryptoError> {
+        sha2::sha256::Sha256::digest(data)
+    }
+
+    fn get_blocksize() -> usize {
+        sha2::sha256::SHA256_BLOCKSIZE
+    }
+}
+
+impl Sha2FuzzType for sha2::sha384::Sha384 {
+    fn new() -> Self {
+        return sha2::sha384::Sha384::new();
+    }
+
+    fn update(&mut self, data: &[u8]) -> Result<(), UnknownCryptoError> {
+        self.update(data)
+    }
+
+    fn finalize(&mut self) -> Result<sha2::sha384::Digest, UnknownCryptoError> {
+        self.finalize()
+    }
+
+    fn digest(data: &[u8]) -> Result<sha2::sha384::Digest, UnknownCryptoError> {
+        sha2::sha384::Sha384::digest(data)
+    }
+
+    fn get_blocksize() -> usize {
+        sha2::sha384::SHA384_BLOCKSIZE
+    }
+}
+
+impl Sha2FuzzType for sha2::sha512::Sha512 {
+    fn new() -> Self {
+        return sha2::sha512::Sha512::new();
+    }
+
+    fn update(&mut self, data: &[u8]) -> Result<(), UnknownCryptoError> {
+        self.update(data)
+    }
+
+    fn finalize(&mut self) -> Result<sha2::sha512::Digest, UnknownCryptoError> {
+        self.finalize()
+    }
+
+    fn digest(data: &[u8]) -> Result<sha2::sha512::Digest, UnknownCryptoError> {
+        sha2::sha512::Sha512::digest(data)
+    }
+
+    fn get_blocksize() -> usize {
+        sha2::sha512::SHA512_BLOCKSIZE
+    }
+}
+
+fn fuzz_sha2(fuzzer_input: &[u8], orion_impl: Sha2FuzzType, ring_impl: ring::digest::Algorithm) {
+    let mut orion_ctx = orion_impl::new();
     let mut collected_data: Vec<u8> = Vec::new();
 
     collected_data.extend_from_slice(fuzzer_input);
     orion_ctx.update(fuzzer_input).unwrap();
 
-    if fuzzer_input.len() > SHA512_BLOCKSIZE {
+    if fuzzer_input.len() > orion_impl::get_blocksize() {
         collected_data.extend_from_slice(b"");
         orion_ctx.update(b"").unwrap();
     }
-    if fuzzer_input.len() > SHA512_BLOCKSIZE * 2 {
+    if fuzzer_input.len() > orion_impl::get_blocksize() * 2 {
         collected_data.extend_from_slice(b"Extra");
         orion_ctx.update(b"Extra").unwrap();
     }
-    if fuzzer_input.len() > SHA512_BLOCKSIZE * 3 {
+    if fuzzer_input.len() > orion_impl::get_blocksize() * 3 {
         collected_data.extend_from_slice(&[0u8; 256]);
         orion_ctx.update(&[0u8; 256]).unwrap();
     }
+    if fuzzer_input.len() > orion_impl::get_blocksize() * 4 {
+        collected_data.extend_from_slice(vec![0u8; orion_impl::get_blocksize() - 1]);
+        orion_ctx.update(&vec![0u8; orion_impl::get_blocksize() - 1]).unwrap();
+    }
 
-    let digest_other = ring::digest::digest(&ring::digest::SHA512, &collected_data);
-    let orion_one_shot = sha512::Sha512::digest(&collected_data).unwrap();
+    let digest_other = ring::digest::digest(&ring_impl, &collected_data);
+    let orion_one_shot = orion_impl::digest(&collected_data).unwrap();
 
     assert!(orion_one_shot == digest_other.as_ref());
     assert!(orion_ctx.finalize().unwrap() == digest_other.as_ref());
@@ -107,8 +189,10 @@ fn main() {
 
             // Test `orion::hazardous::hash::blake2b`
             fuzz_blake2b(data, &mut seeded_rng);
-            // Test `orion::hazardous::hash::sha512`
-            fuzz_sha512(data);
+            // Test `orion::hazardous::hash::sha2`
+            fuzz_sha2(data, sha2::sha256::Sha256, ring::digest::SHA256);
+            fuzz_sha2(data, sha2::sha384::Sha382, ring::digest::SHA384);
+            fuzz_sha2(data, sha2::sha512::Sha512, ring::digest::SHA512);
         });
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -6,7 +6,7 @@ extern crate ring;
 pub mod utils;
 
 use orion::hazardous::hash::blake2b;
-use orion::hazardous::hash::sha512::{self, SHA512_BLOCKSIZE};
+use orion::hazardous::hash::sha2::sha512::{self, SHA512_BLOCKSIZE};
 use utils::{make_seeded_rng, rand_vec_in_range, ChaChaRng, Rng};
 
 const BLAKE2B_BLOCKSIZE: usize = 128;
@@ -69,6 +69,8 @@ fn fuzz_blake2b(fuzzer_input: &[u8], seeded_rng: &mut ChaChaRng) {
         }
     }
 }
+
+// TODO: Add SHA256/384
 
 fn fuzz_sha512(fuzzer_input: &[u8]) {
     let mut orion_ctx = sha512::Sha512::new();

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -5,7 +5,7 @@ extern crate ring;
 extern crate sodiumoxide;
 pub mod utils;
 
-use orion::hazardous::hash::sha512::SHA512_BLOCKSIZE;
+use orion::hazardous::hash::sha2::sha512::SHA512_BLOCKSIZE;
 use orion::hazardous::mac::hmac;
 use orion::hazardous::mac::poly1305;
 use sodiumoxide::crypto::onetimeauth;

--- a/src/newtypes.rs
+++ b/src/newtypes.rs
@@ -105,7 +105,35 @@ pub mod typedefs {
         assert_eq!(sk_rand.len(), BLAKE2B_KEYSIZE / 2);
     }
 
-    // TODO: Add SHA256/384
+    pub fn fuzz_sha256_digest(fuzzer_input: &[u8]) {
+        use orion::hazardous::hash::sha2::sha256::{Digest, SHA256_OUTSIZE};
+
+        if fuzzer_input.len() != SHA256_OUTSIZE {
+            assert!(Digest::from_slice(fuzzer_input).is_err());
+        } else {
+            let hash = Digest::from_slice(fuzzer_input).unwrap();
+
+            assert_eq!(hash.as_ref(), fuzzer_input);
+            assert_eq!(hash, fuzzer_input);
+            assert_eq!(hash.as_ref().len(), fuzzer_input.len());
+            assert_eq!(hash.len(), fuzzer_input.len());
+        }
+    }
+
+    pub fn fuzz_sha384_digest(fuzzer_input: &[u8]) {
+        use orion::hazardous::hash::sha2::sha384::{Digest, SHA384_OUTSIZE};
+
+        if fuzzer_input.len() != SHA384_OUTSIZE {
+            assert!(Digest::from_slice(fuzzer_input).is_err());
+        } else {
+            let hash = Digest::from_slice(fuzzer_input).unwrap();
+
+            assert_eq!(hash.as_ref(), fuzzer_input);
+            assert_eq!(hash, fuzzer_input);
+            assert_eq!(hash.as_ref().len(), fuzzer_input.len());
+            assert_eq!(hash.len(), fuzzer_input.len());
+        }
+    }
 
     pub fn fuzz_sha512_digest(fuzzer_input: &[u8]) {
         use orion::hazardous::hash::sha2::sha512::{Digest, SHA512_OUTSIZE};

--- a/src/newtypes.rs
+++ b/src/newtypes.rs
@@ -105,8 +105,10 @@ pub mod typedefs {
         assert_eq!(sk_rand.len(), BLAKE2B_KEYSIZE / 2);
     }
 
+    // TODO: Add SHA256/384
+
     pub fn fuzz_sha512_digest(fuzzer_input: &[u8]) {
-        use orion::hazardous::hash::sha512::{Digest, SHA512_OUTSIZE};
+        use orion::hazardous::hash::sha2::sha512::{Digest, SHA512_OUTSIZE};
 
         if fuzzer_input.len() != SHA512_OUTSIZE {
             assert!(Digest::from_slice(fuzzer_input).is_err());
@@ -121,7 +123,7 @@ pub mod typedefs {
     }
 
     pub fn fuzz_pbkdf2_password(fuzzer_input: &[u8]) {
-        use orion::hazardous::hash::sha512::{Sha512, SHA512_BLOCKSIZE, SHA512_OUTSIZE};
+        use orion::hazardous::hash::sha2::sha512::{Sha512, SHA512_BLOCKSIZE, SHA512_OUTSIZE};
         use orion::hazardous::kdf::pbkdf2::Password;
 
         let password = Password::from_slice(fuzzer_input).unwrap();
@@ -154,7 +156,7 @@ pub mod typedefs {
     }
 
     pub fn fuzz_hmac_secret_key(fuzzer_input: &[u8]) {
-        use orion::hazardous::hash::sha512::{Sha512, SHA512_BLOCKSIZE, SHA512_OUTSIZE};
+        use orion::hazardous::hash::sha2::sha512::{Sha512, SHA512_BLOCKSIZE, SHA512_OUTSIZE};
         use orion::hazardous::mac::hmac::SecretKey;
 
         let sk = SecretKey::from_slice(fuzzer_input).unwrap();
@@ -187,7 +189,7 @@ pub mod typedefs {
     }
 
     pub fn fuzz_hmac_tag(fuzzer_input: &[u8]) {
-        use orion::hazardous::hash::sha512::SHA512_OUTSIZE;
+        use orion::hazardous::hash::sha2::sha512::SHA512_OUTSIZE;
         use orion::hazardous::mac::hmac::Tag;
 
         if fuzzer_input.len() != SHA512_OUTSIZE {


### PR DESCRIPTION
See https://github.com/brycx/orion/pull/161

NOTE: The updated targets haven't been run yet, due to lack of hardware support from honggfuzz.